### PR TITLE
parse_attributes, identify_parse, deprecated types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ extern "C" {
     pub fn sk_disk_get_size(d: *mut SkDisk, bytes: *mut uint64_t) -> ::libc::c_int;
     pub fn sk_disk_check_sleep_mode(d: *mut SkDisk, awake: *mut SkBool) -> ::libc::c_int;
     pub fn sk_disk_identify_is_available(d: *mut SkDisk, available: *mut SkBool) -> ::libc::c_int;
-    pub fn sk_disk_identify_parse(d: *mut *mut SkDisk, data: *const SkIdentifyParsedData) -> ::libc::c_int;
+    pub fn sk_disk_identify_parse(d: *mut SkDisk, data: *const *const SkIdentifyParsedData) -> ::libc::c_int;
     pub fn sk_disk_smart_is_available(d: *mut SkDisk, available: *mut SkBool) -> ::libc::c_int;
     pub fn sk_disk_smart_status(d: *mut SkDisk, good: *mut SkBool) -> ::libc::c_int;
     pub fn sk_disk_smart_read_data(d: *mut SkDisk) -> ::libc::c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ extern "C" {
     pub fn sk_disk_set_blob(d: *mut SkDisk, blob: *const ::libc::c_void, size: size_t) -> ::libc::c_int;
     pub fn sk_disk_smart_parse(d: *mut *mut SkDisk, data: *const SkSmartParsedData) -> ::libc::c_int;
 
-    pub fn sk_disk_smart_parse_attributes(d: *mut SkDisk, cb: extern fn(d: *mut SkDisk, data: *mut SkSmartAttributeParsedData, userdata: *mut ::libc::c_void), userdata: *mut ::libc::c_void) -> ::libc::c_int;
+    pub fn sk_disk_smart_parse_attributes(d: *mut SkDisk, cb: extern fn(d: *mut SkDisk, data: *const SkSmartAttributeParsedData, userdata: *mut ::libc::c_void), userdata: *mut ::libc::c_void) -> ::libc::c_int;
     
     pub fn sk_disk_smart_self_test(d: *mut SkDisk, test: SkSmartSelfTest) -> ::libc::c_int;
     pub fn sk_disk_smart_get_power_on(d: *mut SkDisk, mseconds: *mut uint64_t) -> ::libc::c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,9 @@ extern "C" {
     pub fn sk_disk_get_blob(d: *mut *mut SkDisk, blob: *const ::libc::c_void, size: *mut size_t) -> ::libc::c_int;
     pub fn sk_disk_set_blob(d: *mut SkDisk, blob: *const ::libc::c_void, size: size_t) -> ::libc::c_int;
     pub fn sk_disk_smart_parse(d: *mut *mut SkDisk, data: *const SkSmartParsedData) -> ::libc::c_int;
-    //pub fn sk_disk_smart_parse_attributes(d: *mut SkDisk, cb: SkSmartAttributeParseCallback, userdata: *mut ::libc::c_void) -> ::libc::c_int;
+
+    pub fn sk_disk_smart_parse_attributes(d: *mut SkDisk, cb: extern fn(d: *mut SkDisk, data: *mut SkSmartAttributeParsedData, userdata: *mut ::libc::c_void), userdata: *mut ::libc::c_void) -> ::libc::c_int;
+    
     pub fn sk_disk_smart_self_test(d: *mut SkDisk, test: SkSmartSelfTest) -> ::libc::c_int;
     pub fn sk_disk_smart_get_power_on(d: *mut SkDisk, mseconds: *mut uint64_t) -> ::libc::c_int;
     pub fn sk_disk_smart_get_power_cycle(d: *mut SkDisk, count: *mut uint64_t) -> ::libc::c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 extern crate libc;
-use self::libc::{c_char, size_t, uint8_t, uint16_t, uint32_t, uint64_t};
+use self::libc::{c_char, size_t};
 
 pub type SkBool = ::libc::c_uint;
 
@@ -58,9 +58,9 @@ pub enum SkSmartSelfTestExecutionStatus {
 pub struct SkSmartParsedData {
     /* Volatile data */
     pub offline_data_collection_status: SkSmartOfflineDataCollectionStatus ,
-    pub total_offline_data_collection_seconds: uint32_t,
+    pub total_offline_data_collection_seconds: u32,
     pub self_test_execution_status: SkSmartSelfTestExecutionStatus,
-    pub self_test_execution_percent_remaining: uint32_t,
+    pub self_test_execution_percent_remaining: u32,
 
     /* Fixed data */
     pub short_and_extended_test_available: SkBool,
@@ -68,9 +68,9 @@ pub struct SkSmartParsedData {
     pub start_test_available: SkBool,
     pub abort_test_available: SkBool,
 
-    pub short_test_polling_minutes: uint32_t,
-    pub extended_test_polling_minutes: uint32_t,
-    pub conveyance_test_polling_minutes: uint32_t,
+    pub short_test_polling_minutes: u32,
+    pub extended_test_polling_minutes: u32,
+    pub conveyance_test_polling_minutes: u32,
 }
 
 #[repr(C)]
@@ -92,11 +92,11 @@ pub enum SkSmartAttributeUnit {
 #[repr(C)]
 #[derive(Debug)]
 pub struct SkSmartAttributeParsedData {
-    pub id: uint8_t,
+    pub id: u8,
     pub name: *const ::libc::c_char,
     pub pretty_unit: SkSmartAttributeUnit,
-    pub flags: uint16_t ,
-    pub threshold: uint8_t,
+    pub flags: u16 ,
+    pub threshold: u8,
     pub threshold_valid: SkBool,
     pub online: SkBool,
     pub prefailure: SkBool,
@@ -107,10 +107,10 @@ pub struct SkSmartAttributeParsedData {
     pub current_value_valid: SkBool,
     pub worst_value_valid: SkBool,
     pub warn: SkBool,
-    pub current_value: uint8_t, 
-    pub worst_value: uint8_t,
-    pub pretty_value: uint64_t,
-    pub raw: [uint8_t; 6],
+    pub current_value: u8, 
+    pub worst_value: u8,
+    pub pretty_value: u64,
+    pub raw: [u8; 6],
 }
 
 pub enum SkDisk{
@@ -135,11 +135,11 @@ extern "C" {
     pub fn sk_smart_offline_data_collection_status_to_string(status: SkSmartOfflineDataCollectionStatus) -> *const ::libc::c_char;
     pub fn sk_smart_self_test_to_string(test: SkSmartSelfTest) -> *const ::libc::c_char;
     pub fn sk_smart_self_test_available(d: *const SkSmartParsedData, test: SkSmartSelfTest) -> SkBool;
-    pub fn sk_smart_self_test_polling_minutes(d: *const SkSmartParsedData, test: SkSmartSelfTest) -> uint32_t;
+    pub fn sk_smart_self_test_polling_minutes(d: *const SkSmartParsedData, test: SkSmartSelfTest) -> u32;
     pub fn sk_smart_attribute_unit_to_string(unit: SkSmartAttributeUnit) -> *const ::libc::c_char;
     pub fn sk_smart_overall_to_string(overall: SkSmartOverall) -> *const ::libc::c_char;
     pub fn sk_disk_open(name: *const ::libc::c_char, d: *mut *mut SkDisk) -> ::libc::c_int;
-    pub fn sk_disk_get_size(d: *mut SkDisk, bytes: *mut uint64_t) -> ::libc::c_int;
+    pub fn sk_disk_get_size(d: *mut SkDisk, bytes: *mut u64) -> ::libc::c_int;
     pub fn sk_disk_check_sleep_mode(d: *mut SkDisk, awake: *mut SkBool) -> ::libc::c_int;
     pub fn sk_disk_identify_is_available(d: *mut SkDisk, available: *mut SkBool) -> ::libc::c_int;
     pub fn sk_disk_identify_parse(d: *mut SkDisk, data: *const *const SkIdentifyParsedData) -> ::libc::c_int;
@@ -149,14 +149,12 @@ extern "C" {
     pub fn sk_disk_get_blob(d: *mut *mut SkDisk, blob: *const ::libc::c_void, size: *mut size_t) -> ::libc::c_int;
     pub fn sk_disk_set_blob(d: *mut SkDisk, blob: *const ::libc::c_void, size: size_t) -> ::libc::c_int;
     pub fn sk_disk_smart_parse(d: *mut *mut SkDisk, data: *const SkSmartParsedData) -> ::libc::c_int;
-
     pub fn sk_disk_smart_parse_attributes(d: *mut SkDisk, cb: extern fn(d: *mut SkDisk, data: *const SkSmartAttributeParsedData, userdata: *mut ::libc::c_void), userdata: *mut ::libc::c_void) -> ::libc::c_int;
-    
     pub fn sk_disk_smart_self_test(d: *mut SkDisk, test: SkSmartSelfTest) -> ::libc::c_int;
-    pub fn sk_disk_smart_get_power_on(d: *mut SkDisk, mseconds: *mut uint64_t) -> ::libc::c_int;
-    pub fn sk_disk_smart_get_power_cycle(d: *mut SkDisk, count: *mut uint64_t) -> ::libc::c_int;
-    pub fn sk_disk_smart_get_bad(d: *mut SkDisk, sectors: *mut uint64_t) -> ::libc::c_int;
-    pub fn sk_disk_smart_get_temperature(d: *mut SkDisk, mkelvin: *mut uint64_t ) -> ::libc::c_int;
+    pub fn sk_disk_smart_get_power_on(d: *mut SkDisk, mseconds: *mut u64) -> ::libc::c_int;
+    pub fn sk_disk_smart_get_power_cycle(d: *mut SkDisk, count: *mut u64) -> ::libc::c_int;
+    pub fn sk_disk_smart_get_bad(d: *mut SkDisk, sectors: *mut u64) -> ::libc::c_int;
+    pub fn sk_disk_smart_get_temperature(d: *mut SkDisk, mkelvin: *mut u64 ) -> ::libc::c_int;
     pub fn sk_disk_smart_get_overall(d: *mut SkDisk, overall: *mut SkSmartOverall) -> ::libc::c_int;
     pub fn sk_disk_dump(d: *mut SkDisk) -> ::libc::c_int;
     pub fn sk_disk_free(d: *mut SkDisk) -> ::libc::c_void;


### PR DESCRIPTION
This PR contains 3 changes, if you'd like me to break it into those pieces I can.

## Changes

### parse_attributes
* uncommented
* Fixed the arguments to accept a callback defined in rust
* example of a callback:

```rust
extern "C" fn callback(d: *mut SkDisk, data: *const SkSmartAttributeParsedData, userdata: *mut c_void) {
    unsafe {
        let name = CStr::from_ptr((*data).name);
        let name_str = name.to_str().unwrap();
        println!("{name_str}");
    }
}
```

### identify_parse
* changed the arguments to accurately match the C arguments

### deprecated types
* Changed deprecated types of uint8_t, uint16_t, uint32_t, uint64_t to u8, u16, u32 respectively 
