### PR TITLE
SkSmartAttributeParsedData struct fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ repository = "https://github.com/cholcombe973/libatasmart-sys"
 
 [dependencies]
 libc = "~0.2"
+c2rust-bitfields = "0.17.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 #![allow(non_camel_case_types)]
 extern crate libc;
-use self::libc::{c_char, size_t};
-
 extern crate c2rust_bitfields;
+use self::libc::{c_char, size_t};
 use c2rust_bitfields::BitfieldStruct;
 
 pub type SkBool = ::libc::c_uint;
@@ -97,7 +96,7 @@ pub enum SkSmartAttributeUnit {
 pub struct SkSmartAttributeParsedData {
     pub id: u8,
     pub name: *const c_char,
-    pub pretty_unit: SkSmartAttributeUnit, /* for pretty_value */
+    pub pretty_unit: SkSmartAttributeUnit,
     pub flags: u16,
     pub threshold: u8,
     #[bitfield(name="threshold_valid", ty="SkBool", bits="0..=0")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 extern crate libc;
 use self::libc::{c_char, size_t};
 
+extern crate c2rust_bitfields;
+use c2rust_bitfields::BitfieldStruct;
+
 pub type SkBool = ::libc::c_uint;
 
 /* ATA SMART test type (ATA8 7.52.5.2) */
@@ -90,24 +93,25 @@ pub enum SkSmartAttributeUnit {
 
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, BitfieldStruct)]
 pub struct SkSmartAttributeParsedData {
     pub id: u8,
-    pub name: *const ::libc::c_char,
-    pub pretty_unit: SkSmartAttributeUnit,
-    pub flags: u16 ,
+    pub name: *const c_char,
+    pub pretty_unit: SkSmartAttributeUnit, /* for pretty_value */
+    pub flags: u16,
     pub threshold: u8,
-    pub threshold_valid: SkBool,
-    pub online: SkBool,
-    pub prefailure: SkBool,
-    pub good_now: SkBool, 
-    pub good_now_valid: SkBool,
-    pub good_in_the_past: SkBool,
-    pub good_in_the_past_valid: SkBool,
-    pub current_value_valid: SkBool,
-    pub worst_value_valid: SkBool,
-    pub warn: SkBool,
-    pub current_value: u8, 
+    #[bitfield(name="threshold_valid", ty="SkBool", bits="0..=0")]
+    #[bitfield(name="online", ty="SkBool", bits="1..=1")]
+    #[bitfield(name="prefailure", ty="SkBool", bits="2..=2")]
+    #[bitfield(name="good_now", ty="SkBool", bits="3..=3")]
+    #[bitfield(name="good_now_valid", ty="SkBool", bits="4..=4")]
+    #[bitfield(name="good_in_the_past", ty="SkBool", bits="5..=5")]
+    #[bitfield(name="good_in_the_past_valid", ty="SkBool", bits="6..=6")]
+    #[bitfield(name="current_value_valid", ty="SkBool", bits="7..=7")]
+    #[bitfield(name="worst_value_valid", ty="SkBool", bits="8..=8")]
+    #[bitfield(name="warn", ty="SkBool", bits="9..=9")]
+    pub threshold_valid_online_prefailure_good_now_good_now_valid_good_in_the_past_good_in_the_past_valid_current_value_valid_worst_value_valid_warn: [u8; 2],
+    pub current_value: u8,
     pub worst_value: u8,
     pub pretty_value: u64,
     pub raw: [u8; 6],


### PR DESCRIPTION
This PR is to fix the issue I brought up in this issue: #3 

It turns out that the c struct in the original library uses bitfields which weren't reflected in the wrapper. Each SkBool type was given only 1 bit, as seen by the ":1" after the field value. eg, `SkBool threshold_valid:1;`

There doesn't seem to be a great way to accomplish this wrapping in rust. I felt like the library `c2rust_bitfields` was a good choice for readability and functionality.  One weird thing with it is the naming scheme, because there are 10 bitfields in a row for this struct, the variable name on line 112 is very long. I used the convention in the library documentation, but it could be changed if you'd like to make it shorter.

In order to access a bitfield you need to call a function on the struct, for example, to get the threshhold_valid value, it'd be `threshold_valid()`. These get auto-generated by `c2rust_bitfields`.