### PR TITLE
`impl Clone, Copy` and update `c2bitfields`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/cholcombe973/libatasmart-sys"
 
 [dependencies]
 libc = "~0.2"
-c2rust-bitfields = "0.17.0"
+c2rust-bitfields = "0.19.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub struct SkSmartParsedData {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum SkSmartAttributeUnit {
     SK_SMART_ATTRIBUTE_UNIT_UNKNOWN,
     SK_SMART_ATTRIBUTE_UNIT_NONE,
@@ -121,7 +121,7 @@ pub enum SkDisk{
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum SkSmartOverall  {
     SK_SMART_OVERALL_GOOD,
     SK_SMART_OVERALL_BAD_ATTRIBUTE_IN_THE_PAST,  /* At least one pre-fail attribute exceeded its threshold in the past */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub type SkBool = ::libc::c_uint;
 
 /* ATA SMART test type (ATA8 7.52.5.2) */
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum SkSmartSelfTest {
     SK_SMART_SELF_TEST_SHORT = 1,
     SK_SMART_SELF_TEST_EXTENDED = 2,
@@ -17,6 +17,7 @@ pub enum SkSmartSelfTest {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy, Debug)]
 pub struct SkIdentifyParsedData {
     pub serial: [c_char; 21],
     pub firmware: [c_char; 9],
@@ -24,7 +25,7 @@ pub struct SkIdentifyParsedData {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Clone, Copy,Debug)]
 pub enum SkSmartOfflineDataCollectionStatus {
     SK_SMART_OFFLINE_DATA_COLLECTION_STATUS_NEVER,
     SK_SMART_OFFLINE_DATA_COLLECTION_STATUS_SUCCESS,
@@ -39,7 +40,7 @@ pub enum SkSmartOfflineDataCollectionStatus {
 
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum SkSmartSelfTestExecutionStatus {
     SK_SMART_SELF_TEST_EXECUTION_STATUS_SUCCESS_OR_NEVER = 0,
     SK_SMART_SELF_TEST_EXECUTION_STATUS_ABORTED = 1,
@@ -56,7 +57,7 @@ pub enum SkSmartSelfTestExecutionStatus {
 
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct SkSmartParsedData {
     /* Volatile data */
     pub offline_data_collection_status: SkSmartOfflineDataCollectionStatus ,
@@ -92,7 +93,7 @@ pub enum SkSmartAttributeUnit {
 
 
 #[repr(C)]
-#[derive(Debug, BitfieldStruct)]
+#[derive(Clone, Copy, Debug, BitfieldStruct)]
 pub struct SkSmartAttributeParsedData {
     pub id: u8,
     pub name: *const c_char,
@@ -116,6 +117,7 @@ pub struct SkSmartAttributeParsedData {
     pub raw: [u8; 6],
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum SkDisk{
 
 }


### PR DESCRIPTION
Allows for cloning and copying the various enums and structs in this lib, and bumps `c2bitfields` to be up-to-date